### PR TITLE
Fix --format available options to be strings instead of symbols

### DIFF
--- a/lib/npmdc/cli.rb
+++ b/lib/npmdc/cli.rb
@@ -15,7 +15,7 @@ module Npmdc
                           default: Npmdc::Config::DEPEPENDENCY_TYPES
     method_option :format, aliases: [:f],
                            desc: 'Output format',
-                           enum: Npmdc::Formatter::FORMATTERS.keys
+                           enum: Npmdc::Formatter::FORMATTERS.keys.map(&:to_s)
 
     def check
       Npmdc.call(options)


### PR DESCRIPTION
It resolves an error with improper format comparison 