### PR TITLE
Start npmdc only with rails server when using with Rails

### DIFF
--- a/lib/npmdc.rb
+++ b/lib/npmdc.rb
@@ -20,5 +20,5 @@ module Npmdc
     end
   end
 
-  require "npmdc/railtie" if defined?(Rails)
+  require "npmdc/railtie" if defined?(Rails::Server)
 end


### PR DESCRIPTION
Start npmdc only with `rails server` when using Rails. Do not start npmdc when running `rake` or other console tasks. 